### PR TITLE
anycable-go: Declare main listening port in the deployment container

### DIFF
--- a/anycable-go/Chart.yaml
+++ b/anycable-go/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for anycable-go websocket server.
 name: anycable-go
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.6.4
 home: https://anycable.io/
 icon: https://docs.anycable.io/assets/images/logo.svg

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -50,15 +50,17 @@ spec:
             weight: 100
       containers:
       - name: anycable-go
+        ports:
+        - name: http
+          containerPort: {{ required "A valid listening port for anycable is required! Please specify `env.anycablePort` in values!" .Values.env.anycablePort }}
+          protocol: TCP
         env:
         {{- if .Values.env.anycableHost }}
         - name: ANYCABLE_HOST
           value: {{ .Values.env.anycableHost | quote }}
         {{- end }}
-        {{- if .Values.env.anycablePort }}
         - name: ANYCABLE_PORT
           value: {{ .Values.env.anycablePort | quote }}
-        {{- end }}
         {{- if .Values.env.anycablePath }}
         - name: ANYCABLE_PATH
           value: {{ .Values.env.anycablePath | quote }}

--- a/anycable-go/templates/service.yml
+++ b/anycable-go/templates/service.yml
@@ -12,7 +12,7 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: {{ .Values.env.anycablePort }}
+    targetPort: http
   selector:
     app: {{ template "anycableGo.name" . }}
     component: anycable-go


### PR DESCRIPTION
It's just weird not to see it in kubectl/k9s output.

Make it required because now it can't be set to `null` without breaking the chart