### PR TITLE
anycable-go: Optional ServiceMonitor for auto-discovery by Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ These are the values used to configure anycable-go itself:
 |**env.anycableMetricsHttp**|Enable HTTP metrics endpoint at the specified path|`/metrics`|
 |**env.anycableMetricsHost**|Server host for metrics endpoint, default: the same as for main server,||
 |**env.anycableMetricsPort**|Server port for metrics endpoint, default: the same as for main server,|`8081`|
+|**serviceMonitor.enabled**|Enable creation of `ServiceMonitor` resource for automatic metrics discovery by Prometheus operator|`false`|
+|**serviceMonitor.namespace**|Namespace to create ServiceMonitor in (if differs from chart's namespace)|_chart's namespace_|
+|**serviceMonitor.interval**|Metrics scrape interval|_Prometheus default_|
+|**serviceMonitor.labels**|Labels that should be present in service monitor to be discovered|`{}`|
 
 ### Ingress configuration
 

--- a/anycable-go/Chart.yaml
+++ b/anycable-go/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for anycable-go websocket server.
 name: anycable-go
-version: 0.2.5
+version: 0.3.0
 appVersion: 0.6.5
 home: https://anycable.io/
 icon: https://docs.anycable.io/assets/images/logo.svg

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -54,6 +54,11 @@ spec:
         - name: http
           containerPort: {{ required "A valid listening port for anycable is required! Please specify `env.anycablePort` in values!" .Values.env.anycablePort }}
           protocol: TCP
+        {{- if .Values.env.anycableMetricsPort }}
+        - name: metrics
+          containerPort: {{ .Values.env.anycableMetricsPort }}
+          protocol: TCP
+        {{- end }}
         env:
         {{- if .Values.env.anycableHost }}
         - name: ANYCABLE_HOST

--- a/anycable-go/templates/service.yml
+++ b/anycable-go/templates/service.yml
@@ -13,6 +13,12 @@ spec:
     port: 80
     protocol: TCP
     targetPort: http
+  {{- if .Values.env.anycableMetricsPort }}
+  - name: metrics
+    port: {{ .Values.env.anycableMetricsPort }}
+    protocol: TCP
+    targetPort: metrics
+  {{- end }}
   selector:
     app: {{ template "anycableGo.name" . }}
     component: anycable-go

--- a/anycable-go/templates/servicemonitor.yaml
+++ b/anycable-go/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and (.Values.env.anycableMetricsPort) (.Values.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "anycableGo.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "anycableGo.name" . }}
+    component: anycable-go
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    {{- range $key, $value := .Values.serviceMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "anycableGo.name" . }}
+      release: {{ .Release.Name | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end -}}

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -67,6 +67,20 @@ readinessProbe:
   failureThreshold: 3
   periodSeconds: 10
 
+serviceMonitor:
+  enabled: false
+  ## Specify a namespace if needed
+  # namespace: monitoring
+  # fallback to the prometheus default unless specified
+  # interval: 10s
+  ## Set of labels that need to be present in ServiceMonitor to be discovered by Prometheus:
+  ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
+  ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+  ## E.g. if you use prometheus-operator:
+  # labels:
+  #   release: prometheus-operator
+  labels: {}
+
 # Application options (passed as env variables)
 env:
   # listen ip address or host


### PR DESCRIPTION
In case if [Prometheus Operator](https://operatorhub.io/operator/prometheus) is being used it allow to automatically configure Prometheus to collect anycable-go metrics.