### PR TITLE
Add conventional healthcheck (liveness, readiness) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ These are the values used to configure anycable-go itself:
 |**env.anycableLogLevel**|Set logging level (debug/info/warn/error/fatal)|`info`|
 |**env.anycableLogFormat**|Set logging format (text, json)|`text`|
 |**env.anycableDebug**|Enable debug mode (more verbose logging)||
+|**env.anycableHealthPath**|HTTP health endpoint path|`/health`|
 |**env.anycableMetricsLog**|Enable metrics logging (with info level)||
 |**env.anycableMetricsLogInterval**|Specify how often flush metrics logs (in seconds)|`15`|
 |**env.anycableMetricsLogFormatter**|Specify the path to custom Ruby formatter script (only supported on MacOS and Linux)||

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -137,6 +137,10 @@ spec:
         - name: ANYCABLE_METRICS_PORT
           value: {{ .Values.env.anycableMetricsPort | quote }}
         {{- end }}
+        {{- if .Values.env.anycableHealthPath }}
+        - name: ANYCABLE_HEALTH_PATH
+          value: {{ .Values.env.anycableHealthPath | quote }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.livenessProbe }}

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -139,3 +139,6 @@ env:
 
   # Server port for metrics endpoint, default: the same as for main server,
   anycableMetricsPort: "8081"
+
+  # HTTP health endpoint path
+  anycableHealthPath: "/health"

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -49,8 +49,8 @@ resources:
 
 livenessProbe:
   httpGet:
-    path: /metrics
-    port: 8081
+    path: /health
+    port: http
   initialDelaySeconds: 90
   timeoutSeconds: 3
   successThreshold: 1
@@ -59,8 +59,8 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /metrics
-    port: 8081
+    path: /health
+    port: http
   initialDelaySeconds: 15
   timeoutSeconds: 3
   successThreshold: 1
@@ -139,4 +139,3 @@ env:
 
   # Server port for metrics endpoint, default: the same as for main server,
   anycableMetricsPort: "8081"
-


### PR DESCRIPTION
- switch liveness/readiness to the health path
- expose health path configuration