### PR TITLE
anycable-go: Add support for using Redis Sentinels

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ These are the values used to configure anycable-go itself:
 |**env.anycableRedisKeepaliveInterval**|Interval to periodically ping Redis to make sure it's alive||
 |**env.anycableRedisChannel**|Redis channel for broadcasts|`__anycable__`|
 |**env.anycableRedisSentinels**|Comma separated list of sentinel hosts, format: `:password@host:port,…`||
-|**env.anycableRedisSentinelDiscoveryInterval**|Interval to rediscover sentinels in seconds||
+|**env.anycableRedisSentinelDiscoveryInterval**|Interval to rediscover sentinels in seconds|`30`|
 |**env.anycableRpcHost**|RPC service address|`localhost:50051`|
 |**env.anycableHeaders**|List of headers to proxy to RPC|`cookie`|
 |**env.anycableDisconnectRate**|Max number of Disconnect calls per second|`100`|

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ These are the values used to configure anycable-go itself:
 |**env.anycableRedisUrl**|Redis DB url|`redis://localhost:6379/5`|
 |**env.anycableRedisKeepaliveInterval**|Interval to periodically ping Redis to make sure it's alive||
 |**env.anycableRedisChannel**|Redis channel for broadcasts|`__anycable__`|
+|**env.anycableRedisSentinels**|Comma separated list of sentinel hosts, format: `:password@host:port,…`||
+|**env.anycableRedisSentinelDiscoveryInterval**|Interval to rediscover sentinels in seconds||
 |**env.anycableRpcHost**|RPC service address|`localhost:50051`|
 |**env.anycableHeaders**|List of headers to proxy to RPC|`cookie`|
 |**env.anycableDisconnectRate**|Max number of Disconnect calls per second|`100`|

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -89,6 +89,17 @@ spec:
         - name: ANYCABLE_REDIS_CHANNEL
           value: {{ .Values.env.anycableRedisChannel | quote }}
         {{- end }}
+        {{- if .Values.env.anycableRedisSentinels }}
+        - name: ANYCABLE_REDIS_SENTINELS
+          valueFrom:
+            secretKeyRef:
+              key: anycableRedisSentinels
+              name: {{ template "anycableGo.fullname" . }}-secrets
+        {{- end }}
+        {{- if .Values.env.anycableRedisSentinelDiscoveryInterval }}
+        - name: ANYCABLE_REDIS_SENTINEL_DISCOVERY_INTERVAL
+          value: {{ .Values.env.anycableRedisSentinelDiscoveryInterval | quote }}
+        {{- end }}
         {{- if .Values.env.anycableRedisKeepaliveInterval }}
         - name: ANYCABLE_REDIS_KEEPALIVE_INTERVAL
           value: {{ .Values.env.anycableRedisKeepaliveInterval | quote }}

--- a/anycable-go/templates/env-secret.yml
+++ b/anycable-go/templates/env-secret.yml
@@ -1,6 +1,9 @@
 apiVersion: v1
 data:
   anycableRedisUrl: {{ .Values.env.anycableRedisUrl | b64enc | quote }}
+  {{- if .Values.env.anycableRedisSentinels }}
+  anycableRedisSentinels: {{ .Values.env.anycableRedisSentinels | b64enc | quote }}
+  {{- end }}
 kind: Secret
 metadata:
   labels:

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -107,8 +107,8 @@ env:
   # Comma separated list of sentinel hosts, format: ':password@hostname:port,..'
   anycableRedisSentinels: ""
 
-  # Interval to rediscover sentinels in seconds, default: 30
-  anycableRedisSentinelDiscoveryInterval: ""
+  # Interval to rediscover sentinels in seconds, anycable-go default: 30
+  anycableRedisSentinelDiscoveryInterval: "30"
 
   # Interval to periodically ping Redis to make sure it's alive, default: 30
   anycableRedisKeepaliveInterval: ""

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -104,6 +104,12 @@ env:
   # Redis channel for broadcasts
   anycableRedisChannel: "__anycable__"
 
+  # Comma separated list of sentinel hosts, format: ':password@hostname:port,..'
+  anycableRedisSentinels: ""
+
+  # Interval to rediscover sentinels in seconds, default: 30
+  anycableRedisSentinelDiscoveryInterval: ""
+
   # Interval to periodically ping Redis to make sure it's alive, default: 30
   anycableRedisKeepaliveInterval: ""
 


### PR DESCRIPTION
Redis Sentinels support was added into anycable-go in 1.0.0. See https://github.com/anycable/anycable-go/pull/95
Support for password protected sentinels was added in 1.0.1. See https://github.com/anycable/anycable-go/pull/109

Blog post about how to use Redis Sentinels in Kubernetes: https://docs.bitnami.com/tutorials/deploy-redis-sentinel-production-cluster/

Example of deploying anycable-go with sentinels:

```sh
helm install anycable-redis bitnami/redis --set "cluster.enabled=true,sentinel.enabled=true,password=password"
helm install anycable-go anycable/anycable-go --set "env.anycableRedisUrl=redis://:password@mymaster:6379/0,env.anycableRedisSentinels=:password@anycable-redis-headless:26379"
```

Note that in this example in `ANYCABLE_REDIS_URL` _name of the master instance_ is specified and in `ANYCABLE_REDIS_SENTINELS` address of headless service is specified (which points into all redis pods: both initial master and slaves)