### PR TITLE
Support custom env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ Only in case if you can't terminate SSL at Ingress controller or need encryption
 
 See `values.yaml` for some more Kubernetes-specific configuration options.
 
+### Custom ENV values
+
+When a new version of anycable become available, the chart can be not updated yet. In this case you would need to add new environment variables to the application.
+These variables can be added to the **env.custom** section of values. Under the hood, custom env variables are passed to the container through the secret.
+
+```yaml
+# ...
+env:
+  # ...
+  custom:
+    NEW_FEATURE: foobar
+```
+
 ## Configuration examples
 
 #### Encrypting communication between ingress-nginx and anycable-go using private CA

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -76,23 +76,9 @@ spec:
         - name: ANYCABLE_SSL_KEY
           value: /etc/ssl/anycable-go/tls.key
         {{- end }}
-        {{- if .Values.env.anycableRedisUrl }}
-        - name: ANYCABLE_REDIS_URL
-          valueFrom:
-            secretKeyRef:
-              key: anycableRedisUrl
-              name: {{ template "anycableGo.fullname" . }}-secrets
-        {{- end }}
         {{- if .Values.env.anycableRedisChannel }}
         - name: ANYCABLE_REDIS_CHANNEL
           value: {{ .Values.env.anycableRedisChannel | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableRedisSentinels }}
-        - name: ANYCABLE_REDIS_SENTINELS
-          valueFrom:
-            secretKeyRef:
-              key: anycableRedisSentinels
-              name: {{ template "anycableGo.fullname" . }}-secrets
         {{- end }}
         {{- if .Values.env.anycableRedisSentinelDiscoveryInterval }}
         - name: ANYCABLE_REDIS_SENTINEL_DISCOVERY_INTERVAL
@@ -158,6 +144,9 @@ spec:
         - name: ANYCABLE_MAX_MESSAGE_SIZE
           value: {{ .Values.env.anycableMaxMessageSize | quote }}
         {{- end }}
+        envFrom:
+          - secretRef:
+              name: "{{ template "anycableGo.fullname" . }}-secrets"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if hasKey .Values "livenessProbe" }}

--- a/anycable-go/templates/env-secret.yml
+++ b/anycable-go/templates/env-secret.yml
@@ -1,8 +1,13 @@
 apiVersion: v1
 data:
-  anycableRedisUrl: {{ .Values.env.anycableRedisUrl | b64enc | quote }}
+  ANYCABLE_REDIS_URL: {{ .Values.env.anycableRedisUrl | b64enc | quote }}
   {{- if .Values.env.anycableRedisSentinels }}
-  anycableRedisSentinels: {{ .Values.env.anycableRedisSentinels | b64enc | quote }}
+  ANYCABLE_REDIS_SENTINELS: {{ .Values.env.anycableRedisSentinels | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.env.custom }}
+  {{- range $key, $val := .Values.env.custom }}
+  {{ $key }}: {{ $val | toString | b64enc | quote }}
+  {{- end }}
   {{- end }}
 kind: Secret
 metadata:

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -165,3 +165,12 @@ env:
 
   # Maximum size of a message in bytes, default: 65536
   anycableMaxMessageSize: ""
+
+  # Under this key you can define custom env variables (for example,
+  # to support new anycable features, not added to the chart yet).
+  # All variables from this part are added to the pod through the secret.
+  #
+  # Example
+  #   custom:
+  #     NEW_FEATURE: foobar
+  custom: {}


### PR DESCRIPTION
Add support for custom environment variables which can be added to future versions of anycable.

Those variables can be added to the `env.custom` section of values, and will be passed as is (stringified and encoded to base64) through the secret object.

---

Also changed the way we use secret (from now and on the secret contains not keys but the plain list of env-s, and it is added to the pod via `fromSecret` section of the manifest).