### PR TITLE
Fix versioning of ingress resources

### DIFF
--- a/anycable-go/templates/_helpers.tpl
+++ b/anycable-go/templates/_helpers.tpl
@@ -17,16 +17,20 @@ Template to generate secrets for a private Docker repository for K8s to use
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
 {{- end }}
 
-{{/*
-Template to generate apiVersion for ingress
-*/}}
-{{- define "apiVersions.ingress" }}
-{{- $apiVersion := "" }}
-{{- $gitVersion := $.Capabilities.KubeVersion.GitVersion -}}
-{{- $apiVersions := $.Capabilities.APIVersions -}}
-{{- if and ($apiVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" $gitVersion) -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
+{{/* Template to generate apiVersion for ingress */}}
+{{- define "anycableGo.apiVersions.ingress" }}
+    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+    {{- $apiVersions := $.Capabilities.APIVersions }}
+
+    {{- if ($kubeVersion | semverCompare ">=1.22.0-0") -}}
+        {{- if $apiVersions.Has "networking.k8s.io/v1" -}}
+            {{- "networking.k8s.io/v1" -}}
+        {{- end -}}
+    {{- else if ($kubeVersion | semverCompare ">=1.19.0-0" | and ($apiVersions.Has "networking.k8s.io/v1")) -}}
+        {{- "networking.k8s.io/v1" -}}
+    {{- else if ($kubeVersion | semverCompare ">=1.14.0-0" | and ($apiVersions.Has "networking.k8s.io/v1beta1")) -}}
+        {{- "networking.k8s.io/v1beta1" -}}
+    {{- else if $apiVersions.Has "extensions/v1beta1" -}}
+        {{- "extensions/v1beta1" -}}
+    {{- end -}}
 {{- end }}

--- a/anycable-go/templates/acme-ingress.yml
+++ b/anycable-go/templates/acme-ingress.yml
@@ -1,7 +1,7 @@
-{{- if and .Values.ingress.enable .Values.ingress.acme }}
+{{- if (.Values.ingress.enable | and .Values.ingress.acme | and .Values.ingress.acme.hosts) }}
 {{- $root := . }}
 {{- $httpLocation := .Values.ingress.path }}
-{{- $apiVersion := include "apiVersions.ingress" $ }}
+{{- $apiVersion := include "anycableGo.apiVersions.ingress" $ }}
 ---
 apiVersion: {{ $apiVersion }}
 kind: Ingress

--- a/anycable-go/templates/ingress.yml
+++ b/anycable-go/templates/ingress.yml
@@ -1,46 +1,47 @@
-{{- if and .Values.ingress.enable .Values.ingress.nonAcme.hosts }}
-{{- $root := . }}
-{{- $httpLocation := .Values.ingress.path }}
-{{- $apiVersion := include "apiVersions.ingress" $ }}
+{{- $apiVersion := include "anycableGo.apiVersions.ingress" $ }}
+{{- with .Values.ingress }}
+{{- if ($apiVersion | and .enable | and .nonAcme.hosts) }}
 ---
-apiVersion: {{- $apiVersion }}
+apiVersion: "{{ $apiVersion }}"
 kind: Ingress
 metadata:
-  name: "{{ template "anycableGo.fullname" $root }}"
+  name: "{{ template "anycableGo.fullname" $ }}"
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
+    {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   tls:
-{{- range $secret := .Values.ingress.nonAcme.hosts }}
+{{- range $secret := .nonAcme.hosts }}
   - hosts:
 {{- range $host := $secret.names }}
     - {{ $host | quote }}
 {{- end }}
     secretName: {{ $secret.secretName | quote }}
 {{- end }}
+{{- if (first .nonAcme.hosts | and (first .nonAcme.hosts).names) }}
   rules:
-{{- range $secret := .Values.ingress.nonAcme.hosts }}
+{{- range $secret := .nonAcme.hosts }}
 {{- range $host := $secret.names }}
-{{- $serviceName := include "anycableGo.fullname" $root }}
+{{- $serviceName := include "anycableGo.fullname" $ }}
   - host: {{ $host | quote }}
     http:
       paths:
-        {{- if eq $apiVersion "networking.k8s.io/v1" }}
-        - path: {{ $httpLocation | quote }}
+        - path: {{ .path | quote }}
+          {{- if eq $apiVersion "networking.k8s.io/v1" }}
           pathType: ImplementationSpecific
           backend:
             service:
               name: {{ $serviceName | quote }}
               port:
                 number: 80
-        {{- else }}
-        - path: {{ $httpLocation | quote }}
+          {{- else }}
           backend:
             serviceName: {{ $serviceName | quote }}
             servicePort: 80
-        {{- end }}
+          {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The reason for this PR is that checking of the `.Capabilities.APIVersions` is not enough to define the proper ingress version.

From the one hand, `.Capabilities.APIVersions.Has "extensions/v1"` can return false positives for k8s versions below `1.19`.
The popular shortcut by adding a resource name to the formula like `.Capabilities.APIVersions.Has "extensions/v1/Ingress"` is not a panacea because it can return false negatives for k8s versions `1.19+`.

That's why I checked k8s versions explicitly for every api version.

***

In the release I also added a couple of checks for parts of ingress and acme ingress resource definitions.