### PR TITLE
Reference service ports from ingress by name

### DIFF
--- a/anycable-go/templates/acme-ingress.yml
+++ b/anycable-go/templates/acme-ingress.yml
@@ -32,12 +32,12 @@ spec:
             service:
               name: {{ $serviceName | quote }}
               port:
-                number: 80
+                name: http
         {{- else }}
         - path: {{ $httpLocation | quote }}
           backend:
             serviceName: {{ $serviceName | quote }}
-            servicePort: 80
+            servicePort: http
         {{- end }}
 {{- end }}
 {{- end }}

--- a/anycable-go/templates/ingress.yml
+++ b/anycable-go/templates/ingress.yml
@@ -34,11 +34,11 @@ spec:
             service:
               name: {{ $serviceName | quote }}
               port:
-                number: 80
+                name: http
           {{- else }}
           backend:
             serviceName: {{ $serviceName | quote }}
-            servicePort: 80
+            servicePort: http
           {{- end }}
 {{- end }}
 {{- end }}

--- a/anycable-go/templates/service.yml
+++ b/anycable-go/templates/service.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 80
+    port: {{ default 80 .Values.env.anycablePort }}
     protocol: TCP
     targetPort: http
   {{- if .Values.env.anycableMetricsPort }}


### PR DESCRIPTION
I believe that it fixes https://github.com/anycable/anycable-helm/issues/15

Relevant docs: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules and some examples in the Internet