### PR TITLE
Make envFrom overridable to dynamically set secrets outside

### DIFF
--- a/anycable-go/templates/_helpers.tpl
+++ b/anycable-go/templates/_helpers.tpl
@@ -41,3 +41,11 @@ Template to generate secrets for a private Docker repository for K8s to use
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Template to
+*/}}
+{{- define "anycableGo.envFrom" -}}
+- secretRef:
+    name: {{ template "anycableGo.fullname" . }}-secrets
+{{- end -}}

--- a/anycable-go/templates/_helpers.tpl
+++ b/anycable-go/templates/_helpers.tpl
@@ -49,3 +49,283 @@ Template to
 - secretRef:
     name: {{ template "anycableGo.fullname" . }}-secrets
 {{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_HOST
+*/}}
+{{- define "anycableGo.anycableHost" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableHost) -}}
+    {{ .Values.global.anycableGo.env.anycableHost | quote }}
+{{- else if not (empty .Values.env.anycableHost) -}}
+    {{ .Values.env.anycableHost | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_PORT
+*/}}
+{{- define "anycableGo.anycablePort" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycablePort) -}}
+    {{ .Values.global.anycableGo.env.anycablePort | quote }}
+{{- else if not (empty .Values.env.anycablePort) -}}
+    {{ .Values.env.anycablePort | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_PATH
+*/}}
+{{- define "anycableGo.anycablePath" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycablePath) -}}
+    {{ .Values.global.anycableGo.env.anycablePath | quote }}
+{{- else if not (empty .Values.env.anycablePath) -}}
+    {{ .Values.env.anycablePath | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_REDIS_CHANNEL
+*/}}
+{{- define "anycableGo.anycableRedisChannel" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRedisChannel) -}}
+    {{ .Values.global.anycableGo.env.anycableRedisChannel | quote }}
+{{- else if not (empty .Values.env.anycableRedisChannel) -}}
+    {{ .Values.env.anycableRedisChannel | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_REDIS_SENTINEL_DISCOVERY_INTERVAL
+*/}}
+{{- define "anycableGo.anycableRedisSentinelDiscoveryInterval" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRedisSentinelDiscoveryInterval) -}}
+    {{ .Values.global.anycableGo.env.anycableRedisSentinelDiscoveryInterval | quote }}
+{{- else if not (empty .Values.env.anycableRedisSentinelDiscoveryInterval) -}}
+    {{ .Values.env.anycableRedisSentinelDiscoveryInterval | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_REDIS_KEEPALIVE_INTERVAL
+*/}}
+{{- define "anycableGo.anycableRedisKeepaliveInterval" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRedisKeepaliveInterval) -}}
+    {{ .Values.global.anycableGo.env.anycableRedisKeepaliveInterval | quote }}
+{{- else if not (empty .Values.env.anycableRedisKeepaliveInterval) -}}
+    {{ .Values.env.anycableRedisKeepaliveInterval | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_RPC_HOST
+*/}}
+{{- define "anycableGo.anycableRpcHost" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRpcHost) -}}
+    {{ .Values.global.anycableGo.env.anycableRpcHost | quote }}
+{{- else if not (empty .Values.env.anycableRpcHost) -}}
+    {{ .Values.env.anycableRpcHost | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_HEADERS
+*/}}
+{{- define "anycableGo.anycableHeaders" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableHeaders) -}}
+    {{ .Values.global.anycableGo.env.anycableHeaders | quote }}
+{{- else if not (empty .Values.env.anycableHeaders) -}}
+    {{ .Values.env.anycableHeaders | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_DISCONNECT_RATE
+*/}}
+{{- define "anycableGo.anycableDisconnectRate" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableDisconnectRate) -}}
+    {{ .Values.global.anycableGo.env.anycableDisconnectRate | quote }}
+{{- else if not (empty .Values.env.anycableDisconnectRate) -}}
+    {{ .Values.env.anycableDisconnectRate | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_LOG_LEVEL
+*/}}
+{{- define "anycableGo.anycableLogLevel" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableLogLevel) -}}
+    {{ .Values.global.anycableGo.env.anycableLogLevel | quote }}
+{{- else if not (empty .Values.env.anycableLogLevel) -}}
+    {{ .Values.env.anycableLogLevel | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_LOG_FORMAT
+*/}}
+{{- define "anycableGo.anycableLogFormat" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableLogFormat) -}}
+    {{ .Values.global.anycableGo.env.anycableLogFormat | quote }}
+{{- else if not (empty .Values.env.anycableLogFormat) -}}
+    {{ .Values.env.anycableLogFormat | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_DEBUG
+*/}}
+{{- define "anycableGo.anycableDebug" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableDebug) -}}
+    {{ .Values.global.anycableGo.env.anycableDebug | quote }}
+{{- else if not (empty .Values.env.anycableDebug) -}}
+    {{ .Values.env.anycableDebug | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_LOG
+*/}}
+{{- define "anycableGo.anycableMetricsLog" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsLog) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsLog | quote }}
+{{- else if not (empty .Values.env.anycableMetricsLog) -}}
+    {{ .Values.env.anycableMetricsLog | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_LOG_INTERVAL
+*/}}
+{{- define "anycableGo.anycableMetricsLogInterval" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsLogInterval) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsLogInterval | quote }}
+{{- else if not (empty .Values.env.anycableMetricsLogInterval) -}}
+    {{ .Values.env.anycableMetricsLogInterval | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_LOG_FORMATTER
+*/}}
+{{- define "anycableGo.anycableMetricsLogFormatter" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsLogFormatter) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsLogFormatter | quote }}
+{{- else if not (empty .Values.env.anycableMetricsLogFormatter) -}}
+    {{ .Values.env.anycableMetricsLogFormatter | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_HTTP
+*/}}
+{{- define "anycableGo.anycableMetricsHttp" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsHttp) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsHttp | quote }}
+{{- else if not (empty .Values.env.anycableMetricsHttp) -}}
+    {{ .Values.env.anycableMetricsHttp | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_HOST
+*/}}
+{{- define "anycableGo.anycableMetricsHost" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsHost) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsHost | quote }}
+{{- else if not (empty .Values.env.anycableMetricsHost) -}}
+    {{ .Values.env.anycableMetricsHost | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_METRICS_PORT
+*/}}
+{{- define "anycableGo.anycableMetricsPort" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMetricsPort) -}}
+    {{ .Values.global.anycableGo.env.anycableMetricsPort | quote }}
+{{- else if not (empty .Values.env.anycableMetricsPort) -}}
+    {{ .Values.env.anycableMetricsPort | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_HEALTH_PATH
+*/}}
+{{- define "anycableGo.anycableHealthPath" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableHealthPath) -}}
+    {{ .Values.global.anycableGo.env.anycableHealthPath | quote }}
+{{- else if not (empty .Values.env.anycableHealthPath) -}}
+    {{ .Values.env.anycableHealthPath | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_MAX_MESSAGE_SIZE
+*/}}
+{{- define "anycableGo.anycableMaxMessageSize" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableMaxMessageSize) -}}
+    {{ .Values.global.anycableGo.env.anycableMaxMessageSize | quote }}
+{{- else if not (empty .Values.env.anycableMaxMessageSize) -}}
+    {{ .Values.env.anycableMaxMessageSize | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_REDIS_URL
+*/}}
+{{- define "anycableGo.anycableRedisUrl" -}}
+{{- if not (empty .Values.global.anycableGo.redisUrlSecret) -}}
+secretKeyRef:
+    name: {{ .Values.global.anycableGo.redisUrlSecret.name }}
+    key: {{ .Values.global.anycableGo.redisUrlSecret.key }}
+{{- else if not (empty .Values.redisUrlSecret) -}}
+secretKeyRef:
+    name: {{ .Values.redisUrlSecret.name }}
+    key: {{ .Values.redisUrlSecret.key }}
+{{- else -}}
+secretKeyRef:
+    name: {{ template "anycableGo.fullname" . }}-secrets
+    key: ANYCABLE_REDIS_URL
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_REDIS_SENTINELS
+*/}}
+{{- define "anycableGo.anycableRedisSentinels" -}}
+{{- if not (empty .Values.global.anycableGo.redisSentinelsSecret) -}}
+secretKeyRef:
+    name: {{ .Values.global.anycableGo.redisSentinelsSecret.name }}
+    key: {{ .Values.global.anycableGo.redisSentinelsSecret.key }}
+{{- else if not (empty .Values.redisSentinelsSecret) -}}
+secretKeyRef:
+    name: {{ .Values.redisSentinelsSecret.name }}
+    key: {{ .Values.redisSentinelsSecret.key }}
+{{- else -}}
+secretKeyRef:
+    name: {{ template "anycableGo.fullname" . }}-secrets
+    key: ANYCABLE_REDIS_SENTINELS
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for the Redis URL
+*/}}
+{{- define "anycableGo.redisUrl" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRedisUrl) -}}
+    {{ .Values.global.anycableGo.env.anycableRedisUrl }}
+{{- else if not (empty .Values.env.anycableRedisUrl) -}}
+    {{ .Values.env.anycableRedisUrl }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Template to provide a value for ANYCABLE_MAX_MESSAGE_SIZE
+*/}}
+{{- define "anycableGo.redisSentinels" -}}
+{{- if not (empty .Values.global.anycableGo.env.anycableRedisSentinels) -}}
+    {{ .Values.global.anycableGo.env.anycableRedisSentinels }}
+{{- else if not (empty .Values.env.anycableRedisSentinels) -}}
+    {{ .Values.env.anycableRedisSentinels }}
+{{- end -}}
+{{- end -}}

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -64,90 +64,56 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-        {{- if .Values.env.anycableHost }}
         - name: ANYCABLE_HOST
-          value: {{ .Values.env.anycableHost | quote }}
-        {{- end }}
+          value: {{ template "anycableGo.anycableHost" . }}
         - name: ANYCABLE_PORT
-          value: {{ .Values.env.anycablePort | quote }}
-        {{- if .Values.env.anycablePath }}
+          value: {{ template "anycableGo.anycablePort" . }}
         - name: ANYCABLE_PATH
-          value: {{ .Values.env.anycablePath | quote }}
-        {{- end }}
+          value: {{ template "anycableGo.anycablePath" . }}
         {{- if .Values.tls }}
         - name: ANYCABLE_SSL_CERT
           value: /etc/ssl/anycable-go/tls.crt
         - name: ANYCABLE_SSL_KEY
           value: /etc/ssl/anycable-go/tls.key
         {{- end }}
-        {{- if .Values.env.anycableRedisChannel }}
         - name: ANYCABLE_REDIS_CHANNEL
-          value: {{ .Values.env.anycableRedisChannel | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableRedisSentinelDiscoveryInterval }}
+          value: {{ template "anycableGo.anycableRedisChannel" . }}
         - name: ANYCABLE_REDIS_SENTINEL_DISCOVERY_INTERVAL
-          value: {{ .Values.env.anycableRedisSentinelDiscoveryInterval | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableRedisKeepaliveInterval }}
+          value: {{ template "anycableGo.anycableRedisSentinelDiscoveryInterval" . }}
         - name: ANYCABLE_REDIS_KEEPALIVE_INTERVAL
-          value: {{ .Values.env.anycableRedisKeepaliveInterval | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableRpcHost }}
+          value: {{ template "anycableGo.anycableRedisKeepaliveInterval" . }}
         - name: ANYCABLE_RPC_HOST
-          value: {{ .Values.env.anycableRpcHost | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableHeaders }}
+          value: {{ template "anycableGo.anycableRpcHost" . }}
         - name: ANYCABLE_HEADERS
-          value: {{ .Values.env.anycableHeaders | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableDisconnectRate }}
+          value: {{ template "anycableGo.anycableHeaders" . }}
         - name: ANYCABLE_DISCONNECT_RATE
-          value: {{ .Values.env.anycableDisconnectRate | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableLogLevel }}
+          value: {{ template "anycableGo.anycableDisconnectRate" . }}
         - name: ANYCABLE_LOG_LEVEL
-          value: {{ .Values.env.anycableLogLevel | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableLogFormat }}
+          value: {{ template "anycableGo.anycableLogLevel" . }}
         - name: ANYCABLE_LOG_FORMAT
-          value: {{ .Values.env.anycableLogFormat | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableDebug }}
+          value: {{ template "anycableGo.anycableLogFormat" . }}
         - name: ANYCABLE_DEBUG
-          value: {{ .Values.env.anycableDebug | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsLog }}
+          value: {{ template "anycableGo.anycableDebug" . }}
         - name: ANYCABLE_METRICS_LOG
-          value: {{ .Values.env.anycableMetricsLog | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsLogInterval }}
+          value: {{ template "anycableGo.anycableMetricsLog" . }}
         - name: ANYCABLE_METRICS_LOG_INTERVAL
-          value: {{ .Values.env.anycableMetricsLogInterval | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsLogFormatter }}
+          value: {{ template "anycableGo.anycableMetricsLogInterval" . }}
         - name: ANYCABLE_METRICS_LOG_FORMATTER
-          value: {{ .Values.env.anycableMetricsLogFormatter | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsHttp }}
+          value: {{ template "anycableGo.anycableMetricsLogFormatter" . }}
         - name: ANYCABLE_METRICS_HTTP
-          value: {{ .Values.env.anycableMetricsHttp | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsHost }}
+          value: {{ template "anycableGo.anycableMetricsHttp" . }}
         - name: ANYCABLE_METRICS_HOST
-          value: {{ .Values.env.anycableMetricsHost | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMetricsPort }}
+          value: {{ template "anycableGo.anycableMetricsHost" . }}
         - name: ANYCABLE_METRICS_PORT
-          value: {{ .Values.env.anycableMetricsPort | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableHealthPath }}
+          value: {{ template "anycableGo.anycableMetricsPort" . }}
         - name: ANYCABLE_HEALTH_PATH
-          value: {{ .Values.env.anycableHealthPath | quote }}
-        {{- end }}
-        {{- if .Values.env.anycableMaxMessageSize }}
+          value: {{ template "anycableGo.anycableHealthPath" . }}
         - name: ANYCABLE_MAX_MESSAGE_SIZE
-          value: {{ .Values.env.anycableMaxMessageSize | quote }}
-        {{- end }}
+          value: {{ template "anycableGo.anycableMaxMessageSize" . }}
+        - name: ANYCABLE_REDIS_URL
+          valueFrom: {{ include "anycableGo.anycableRedisUrl" . | nindent 12 }}
+        - name: ANYCABLE_REDIS_SENTINELS
+          valueFrom: {{ include "anycableGo.anycableRedisSentinels" . | nindent 12 }}
         envFrom: {{ include "anycableGo.envFrom" . | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -148,9 +148,7 @@ spec:
         - name: ANYCABLE_MAX_MESSAGE_SIZE
           value: {{ .Values.env.anycableMaxMessageSize | quote }}
         {{- end }}
-        envFrom:
-          - secretRef:
-              name: "{{ template "anycableGo.fullname" . }}-secrets"
+        envFrom: {{ include "anycableGo.envFrom" . | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if hasKey .Values "livenessProbe" }}

--- a/anycable-go/templates/env-secret.yml
+++ b/anycable-go/templates/env-secret.yml
@@ -1,9 +1,7 @@
 apiVersion: v1
 data:
-  ANYCABLE_REDIS_URL: {{ .Values.env.anycableRedisUrl | b64enc | quote }}
-  {{- if .Values.env.anycableRedisSentinels }}
-  ANYCABLE_REDIS_SENTINELS: {{ .Values.env.anycableRedisSentinels | b64enc | quote }}
-  {{- end }}
+  ANYCABLE_REDIS_URL: {{ (include "anycableGo.redisUrl" .) | b64enc | quote }}
+  ANYCABLE_REDIS_SENTINELS: {{ (include "anycableGo.redisSentinels" .) | b64enc | quote }}
   {{- if .Values.env.custom }}
   {{- range $key, $val := .Values.env.custom }}
   {{ $key }}: {{ $val | toString | b64enc | quote }}

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -15,11 +15,9 @@ image:
 ingress:
   enable: false
   path: /cable
-  annotations:
-    {}
+  annotations: {}
     # nginx.ingress.kubernetes.io/proxy-body-size: "32m"
-  acme:
-    {}
+  acme: {}
     # hosts: []
   nonAcme:
     hosts: []
@@ -47,8 +45,7 @@ global:
   anycableGo:
     env: {}
 
-    redisUrlSecret:
-      {}
+    redisUrlSecret: {}
       # name: my-secret
       # key: ANYCABLE_REDIS_URL
 
@@ -86,13 +83,11 @@ resources:
 # livenessProbe: ~
 # readinessProbe: ~
 
-redisUrlSecret:
-  {}
+redisUrlSecret: {}
   # name: my-secret
   # key: ANYCABLE_REDIS_URL
 
-redisSentinelsSecret:
-  {}
+redisSentinelsSecret: {}
   # name: my-secret
   # key: ANYCABLE_REDIS_SENTINELS
 
@@ -110,8 +105,7 @@ serviceMonitor:
   #   release: prometheus-operator
   labels: {}
 
-tls:
-  {}
+tls: {}
   # secretName: "anycable-go-tls-secret"
   # Keep empty to use existing secret
   # crt: ~

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -15,9 +15,11 @@ image:
 ingress:
   enable: false
   path: /cable
-  annotations: {}
+  annotations:
+    {}
     # nginx.ingress.kubernetes.io/proxy-body-size: "32m"
-  acme: {}
+  acme:
+    {}
     # hosts: []
   nonAcme:
     hosts: []
@@ -35,12 +37,20 @@ ingress:
   #     crt: ""
   #     key: ""
 
-
 revisionHistoryLimit: 10
 
 rollingUpdate:
   maxSurge: 1
   maxUnavailable: 0
+
+global:
+  anycableGo:
+    env: {}
+
+    redisUrlSecret:
+      {}
+      # name: my-secret
+      # key: ANYCABLE_REDIS_URL
 
 # Default resource limits for items API app.
 # Do not forget to tune them to match your needs.
@@ -76,6 +86,16 @@ resources:
 # livenessProbe: ~
 # readinessProbe: ~
 
+redisUrlSecret:
+  {}
+  # name: my-secret
+  # key: ANYCABLE_REDIS_URL
+
+redisSentinelsSecret:
+  {}
+  # name: my-secret
+  # key: ANYCABLE_REDIS_SENTINELS
+
 serviceMonitor:
   enabled: false
   ## Specify a namespace if needed
@@ -90,7 +110,8 @@ serviceMonitor:
   #   release: prometheus-operator
   labels: {}
 
-tls: {}
+tls:
+  {}
   # secretName: "anycable-go-tls-secret"
   # Keep empty to use existing secret
   # crt: ~
@@ -127,7 +148,7 @@ env:
   anycableRedisSentinelDiscoveryInterval: "30"
 
   # Interval to periodically ping Redis to make sure it's alive, default: 30
-  anycableRedisKeepaliveInterval: ""
+  anycableRedisKeepaliveInterval: "30"
 
   # RPC service address
   anycableRpcHost: "localhost:50051"
@@ -169,7 +190,7 @@ env:
   anycableHealthPath: "/health"
 
   # Maximum size of a message in bytes, default: 65536
-  anycableMaxMessageSize: ""
+  anycableMaxMessageSize: "65536"
 
   # Under this key you can define custom env variables (for example,
   # to support new anycable features, not added to the chart yet).


### PR DESCRIPTION
The current chart is very inflexible when being used as a sub chart as all properties have to be set via `values.yml` and can't be dynamic. Using a `template` is a common way to override the value dynamically in a parent chart.

I'm pretty sure there are a lot of other opportunities in the chart to dynamize this. If you're happy with the approach, I will open another PR to apply those kinds of changes to all environment variables.

## References

* [Bitnami Redis Chart](https://github.com/bitnami/charts/blob/master/bitnami/redis/templates/master/statefulset.yaml#L122-L126)