### PR TITLE
Allow user annotations and serviceAccountName

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ These are the values used to configure anycable-go itself:
 |-----|-----------|-------|
 |**annotations**|User-specified Pod annotations|`{}`|
 |**service.annotations**|User-specified Service annotations|`{}`|
+|**serviceAccountName**|User-specified ServiceAccount for Pod identity||
 
 ### Monitoring
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ These are the values used to configure anycable-go itself:
 
 |Value|Description|Default|
 |-----|-----------|-------|
-|**annotations**|User-specified Pod annotations|`{}`|
+|**pod.annotations**|User-specified Pod annotations|`{}`|
+|**pod.serviceAccountName**|User-specified ServiceAccount for Pod identity||
 |**service.annotations**|User-specified Service annotations|`{}`|
-|**serviceAccountName**|User-specified ServiceAccount for Pod identity||
 
 ### Monitoring
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ These are the values used to configure anycable-go itself:
 |**env.anycableDisconnectRate**|Max number of Disconnect calls per second|`100`|
 |**env.anycableMaxMessageSize**|Maximum size of a message in bytes|`` (uses anycable-go default: 65536)|
 
+### Kubernetes
+
+|Value|Description|Default|
+|-----|-----------|-------|
+|**annotations**|User-specified Pod annotations|`{}`|
+|**service.annotations**|User-specified Service annotations|`{}`|
+
 ### Monitoring
 
 |Value|Description|Default|

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -44,6 +44,9 @@ spec:
         {{- end }}
       name: {{ $.Release.Name | quote }}
     spec:
+      {{- if .serviceAccountName }}
+      serviceAccountName: {{ .serviceAccountName }}
+      {{- end }}
       {{- if .nodeSelector }}
       nodeSelector: {{ toYaml .nodeSelector | nindent 8 }}
       {{- end }}

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -37,6 +37,11 @@ spec:
         heritage: {{ $.Release.Service | quote }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env-secret.yml") $ | sha256sum }}
+        {{- if .annotations }}
+        {{- range $key, $value := .annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
       name: {{ $.Release.Name | quote }}
     spec:
       {{- if .nodeSelector }}

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -37,15 +37,13 @@ spec:
         heritage: {{ $.Release.Service | quote }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env-secret.yml") $ | sha256sum }}
-        {{- if .annotations }}
-        {{- range $key, $value := .annotations }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{- if (.pod | default dict).annotations }}
+        {{- .pod.annotations | toYaml | nindent 8 }}
         {{- end }}
       name: {{ $.Release.Name | quote }}
     spec:
-      {{- if .serviceAccountName }}
-      serviceAccountName: {{ .serviceAccountName }}
+      {{- if (.pod | default dict).serviceAccountName }}
+      serviceAccountName: {{ pod.serviceAccountName }}
       {{- end }}
       {{- if .nodeSelector }}
       nodeSelector: {{ toYaml .nodeSelector | nindent 8 }}

--- a/anycable-go/templates/service.yml
+++ b/anycable-go/templates/service.yml
@@ -9,7 +9,16 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}
+  {{- if hasKey $values.service "annotations" }}
+    {{- if $values.service.annotations }}
+      {{- range $key, $value := $values.service.annotations }}
+  annotations:
+    {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   name: {{ template "anycableGo.fullname" $ }}
+
 spec:
   ports:
     - name: http

--- a/anycable-go/templates/service.yml
+++ b/anycable-go/templates/service.yml
@@ -9,13 +9,8 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}
-  {{- if hasKey $values.service "annotations" }}
-    {{- if $values.service.annotations }}
-      {{- range $key, $value := $values.service.annotations }}
-  annotations:
-    {{ $key }}: {{ $value | quote }}
-      {{- end }}
-    {{- end }}
+  {{- if ($values.service | default dict).annotations }}
+  annotations: {{ $values.service.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ template "anycableGo.fullname" $ }}
 

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -56,6 +56,10 @@ annotations: {}
 service:
   annotations: {}
 
+# Use a different ServiceAccount
+# (leave blank for default)
+serviceAccountName: ""
+
 # Define names or additional secrets to overwrite env variables
 # from the `env-secret.yml`.
 # (`ANYCABLE_REDIS_URL`, `ANYCABLE_REDIS_SENTINELS`, etc.)

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -51,6 +51,11 @@ resources:
     cpu: 350m
     memory: 400Mi
 
+annotations: {}
+
+service:
+  annotations: {}
+
 # Define names or additional secrets to overwrite env variables
 # from the `env-secret.yml`.
 # (`ANYCABLE_REDIS_URL`, `ANYCABLE_REDIS_SENTINELS`, etc.)

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -51,14 +51,15 @@ resources:
     cpu: 350m
     memory: 400Mi
 
-annotations: {}
+pod:
+  annotations: {}
+
+  # Use a different ServiceAccount
+  # (leave blank for default)
+  serviceAccountName: ""
 
 service:
   annotations: {}
-
-# Use a different ServiceAccount
-# (leave blank for default)
-serviceAccountName: ""
 
 # Define names or additional secrets to overwrite env variables
 # from the `env-secret.yml`.


### PR DESCRIPTION
# Background
I had the need to configure annotations for my AnyCable Service resource in EKS (specifically, to correctly configure a health-check for the ALB Ingress Controller), as well as Pod annotations for sidecar injection. The latter also required running the pod with a different ServiceAccount. I suppose other people may eventually need to do this as well.
 
This change adds new top-level keys to `values.yaml` which allow parameterization of Service annotations, Pod annotations, and Pod `serviceAccountName`.

(Deployment annotations were arbitrarily not added because I didn't need them.)

# Implementation Considerations

Most Deployment-related options are enumerated in `values.yaml` as top-level keys (for convenience, I presume). As is done with Ingress currently, I would have preferred to instead refactor all Deployment-related values to be nested under a `deployment` key, but didn't want to conflate concerns or change it without talking to you first.

But, instead of adding a top-level key named `serviceAnnotations`, Service annotations are configured similar to that of Ingress:
```yaml
    service:
      annotations:
        foo: bar
        baz: qux
```

Thanks.