### PR TITLE
Allow user to specify custom `command` and `args` for container

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ These are the values used to configure anycable-go itself:
 |**env.anycableHeaders**|List of headers to proxy to RPC|`cookie`|
 |**env.anycableDisconnectRate**|Max number of Disconnect calls per second|`100`|
 |**env.anycableMaxMessageSize**|Maximum size of a message in bytes|`` (uses anycable-go default: 65536)|
+|**command**|Override entrypoint for Alpine images|`/usr/local/bin/anycable-go`
+|**args**|Customize ARGV (in addition to `env` settings above)|`[]`|
 
 ### Monitoring
 

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -58,6 +58,16 @@ spec:
       {{- end }}
       containers:
         - name: anycable-go
+          {{- if and (hasKey $values "command") (.command) }}
+          command:
+            - {{ .command }}
+          {{- end }}
+          {{- if and (hasKey $values "args") (.args) }}
+          args:
+            {{- range $arg := .args }}
+            - {{ $arg | quote }}
+            {{- end }}
+          {{- end }}
           {{- with .env }}
           ports:
             - name: http

--- a/anycable-go/templates/deployment.yml
+++ b/anycable-go/templates/deployment.yml
@@ -58,11 +58,11 @@ spec:
       {{- end }}
       containers:
         - name: anycable-go
-          {{- if and (hasKey $values "command") (.command) }}
+          {{- if .command }}
           command:
-            - {{ .command }}
+            - {{ .command | quote }}
           {{- end }}
-          {{- if and (hasKey $values "args") (.args) }}
+          {{- if .args }}
           args:
             {{- range $arg := .args }}
             - {{ $arg | quote }}


### PR DESCRIPTION
This is useful in case operator wants to launch a shell first and customize the environment further. For example, external volumes (outside of Helm) may have been patched to the Pod by sidecars that were injected via mutating admission hooks.