### PR TITLE
Allow `ANYCABLE_REDIS_URL` to be empty

### DIFF
--- a/anycable-go/templates/env-secret.yml
+++ b/anycable-go/templates/env-secret.yml
@@ -49,7 +49,9 @@ data:
   ANYCABLE_PATH: {{ .anycablePath | b64enc | quote }} # {{ .anycablePath }}
   {{- end }}
   ANYCABLE_PORT: {{ .anycablePort | b64enc | quote }} # {{ .anycablePort }}
+  {{- if .anycableRedisUrl }}
   ANYCABLE_REDIS_URL: {{ .anycableRedisUrl | b64enc | quote }} # {{ .anycableRedisUrl }}
+  {{- end }}
   {{- if .anycableRedisChannel }}
   ANYCABLE_REDIS_CHANNEL: {{ .anycableRedisChannel | b64enc | quote }} # {{ .anycableRedisChannel }}
   {{- end }}


### PR DESCRIPTION
This allows the user to leverage `$REDIS_URL` from the existing environment which may have been provisioned from secrets injection (eg., Vault sidecar injector). This way they don't have to duplicate an existing secret value as `$ANYCABLE_REDIS_URL` (i.e., DRY).