### PR TITLE
Fix wrong scoped .path within outer range

### DIFF
--- a/anycable-go/templates/acme-ingress.yml
+++ b/anycable-go/templates/acme-ingress.yml
@@ -26,7 +26,7 @@ spec:
       http:
         paths:
           {{- if eq $apiVersion "networking.k8s.io/v1" }}
-          - path: {{ .path | quote }}
+          - path: {{ $values.ingress.path | quote }}
             pathType: ImplementationSpecific
             backend:
               service:
@@ -34,7 +34,7 @@ spec:
                 port:
                   name: http
           {{- else }}
-          - path: {{ .path | quote }}
+          - path: {{ $values.ingress.path | quote }}
             backend:
               serviceName: {{ $serviceName | quote }}
               servicePort: http


### PR DESCRIPTION
`{{- range $host := .acme.hosts }}` overrides the scope from top `{{- with $values.ingress }}`