### PR TITLE
Fix: hpa metric for autoscaling/v2

### DIFF
--- a/anycable-go/templates/hpa.yaml
+++ b/anycable-go/templates/hpa.yaml
@@ -21,6 +21,14 @@ spec:
   maxReplicas: {{ .maxReplicas }}
   {{- if eq $apiVersion "autoscaling/v1" }}
   targetCPUUtilizationPercentage: {{ .targetCPUUtilizationPercentage }}
+  {{- else if eq $apiVersion "autoscaling/v2" }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
     - type: Resource


### PR DESCRIPTION

# Fix: hpa metric for autoscaling/v2

## why?

the version `"autoscaling/v2"` was not covered in the hpa template. 

tested modifying the values `hpa.enabled: true` and running 

```bash
helm template . -s templates/hpa.yaml --validate
```

## ps

the block below represent hpa ``"autoscaling/v2beta1"` and ``"autoscaling/v2beta2"`

```yaml
{{- else }}
  metrics:
    - type: Resource
      resource:
        name: cpu
        targetAverageUtilization: {{ .targetCPUUtilizationPercentage }}
  {{- end }}
```


