### PR TITLE
Release 0.5.9

### DIFF
--- a/anycable-go/Chart.yaml
+++ b/anycable-go/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for anycable-go websocket server.
 name: anycable-go
-version: 0.5.8
+version: 0.5.9
 appVersion: 1.2.4
 home: https://anycable.io/
 icon: https://docs.anycable.io/assets/images/logo.svg

--- a/anycable-go/templates/hpa.yaml
+++ b/anycable-go/templates/hpa.yaml
@@ -21,6 +21,14 @@ spec:
   maxReplicas: {{ .maxReplicas }}
   {{- if eq $apiVersion "autoscaling/v1" }}
   targetCPUUtilizationPercentage: {{ .targetCPUUtilizationPercentage }}
+  {{- else if eq $apiVersion "autoscaling/v2" }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
     - type: Resource

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -11,7 +11,7 @@ hpa:
 
 image:
   repository: anycable/anycable-go
-  tag: 1.2.4
+  tag: 1.2.3
   pullPolicy: IfNotPresent
   pullSecrets:
     enabled: false


### PR DESCRIPTION
- Fix: hpa metric for autoscaling/v2
- fix the actual anycable-go image tag
- Release 0.5.9: HPA autoscaling/v2 support for the default hpa resource.
