### PR TITLE
Fix hpa for apiVersion autoscaling/v2beta2

### DIFF
--- a/anycable-go/templates/hpa.yaml
+++ b/anycable-go/templates/hpa.yaml
@@ -21,7 +21,7 @@ spec:
   maxReplicas: {{ .maxReplicas }}
   {{- if eq $apiVersion "autoscaling/v1" }}
   targetCPUUtilizationPercentage: {{ .targetCPUUtilizationPercentage }}
-  {{- else if eq $apiVersion "autoscaling/v2" }}
+  {{- else if or (eq $apiVersion "autoscaling/v2") (eq $apiVersion "autoscaling/v2beta2") }}
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
We're on v1.22 of Kubernetes and have found the v2beta2 version of the hpa api wants the same fields as v2. See here for reference: https://v1-22.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
