### PR TITLE
Add support 1.5.3 version

### DIFF
--- a/anycable-go/Chart.yaml
+++ b/anycable-go/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for anycable-go websocket server.
 name: anycable-go
 version: 0.5.11
-appVersion: 1.4.7
+appVersion: 1.5.3
 home: https://anycable.io/
 icon: https://docs.anycable.io/assets/images/logo.svg
 keywords:

--- a/anycable-go/templates/env-secret.yml
+++ b/anycable-go/templates/env-secret.yml
@@ -48,6 +48,9 @@ data:
   {{- if .anycableRedisTlsClientKeyPath }}
   ANYCABLE_REDIS_TLS_CLIENT_KEY_PATH: {{ .anycableRedisTlsClientKeyPath | toString | b64enc | quote }} # {{ .anycableRedisTlsClientKeyPath }}
   {{- end }}
+  {{- if .anycableRedisDisableCache }}
+  ANYCABLE_REDIS_DISABLE_CACHE: {{ .anycableRedisDisableCache | toString | b64enc | quote }} # {{ .anycableRedisTlsClientKeyPath }}
+  {{- end }}
   {{- if .anycableRpcConcurrency }}
   ANYCABLE_RPC_CONCURRENCY: {{ .anycableRpcConcurrency | toString | b64enc | quote }} # {{ .anycableRpcConcurrency }}
   {{- end }}
@@ -255,23 +258,47 @@ data:
   {{- if .anycableJwtIdKey }}
   ANYCABLE_JWT_ID_KEY: {{ .anycableJwtIdKey | toString | b64enc | quote }} # {{ .anycableJwtIdKey }}
   {{- end }}
+  {{- if .anycableJwtSecret }}
+  ANYCABLE_JWT_SECRET: {{ .anycableJwtSecret | toString | b64enc | quote }} # {{ .anycableJwtSecret }}
+  {{- end }}
   {{- if .anycableJwtIdParam }}
   ANYCABLE_JWT_ID_PARAM: {{ .anycableJwtIdParam | toString | b64enc | quote }} # {{ .anycableJwtIdParam }}
+  {{- end }}
+  {{- if .anycableJwtParam }}
+  ANYCABLE_JWT_PARAM: {{ .anycableJwtParam | toString | b64enc | quote }} # {{ .anycableJwtParam }}
   {{- end }}
   {{- if .anycableJwtIdEnforce }}
   ANYCABLE_JWT_ID_ENFORCE: {{ .anycableJwtIdEnforce | toString | b64enc | quote }} # {{ .anycableJwtIdEnforce }}
   {{- end }}
+  {{- if .anycableEnforceJwt }}
+  ANYCABLE_ENFORCE_JWT: {{ .anycableEnforceJwt | toString | b64enc | quote }} # {{ .anycableEnforceJwt }}
+  {{- end }}
   {{- if .anycableTurboRailsKey }}
   ANYCABLE_TURBO_RAILS_KEY: {{ .anycableTurboRailsKey | toString | b64enc | quote }} # {{ .anycableTurboRailsKey }}
   {{- end }}
-  {{- if .anycableTurboRailsCleartext }}
-  ANYCABLE_TURBO_RAILS_CLEARTEXT: {{ .anycableTurboRailsCleartext | toString | b64enc | quote }} # {{ .anycableTurboRailsCleartext }}
+  {{- if .anycablePublicStreams }}
+  ANYCABLE_PUBLIC_STREAMS: {{ .anycablePublicStreams | toString | b64enc | quote }} # {{ .anycablePublicStreams }}
+  {{- end }}
+  {{- if .anycableStreamsSecret }}
+  ANYCABLE_STREAMS_SECRET: {{ .anycableStreamsSecret | toString | b64enc | quote }} # {{ .anycableStreamsSecret }}
+  {{- end }}
+  {{- if .anycableTurboStreamsSecret }}
+  ANYCABLE_TURBO_STREAMS_SECRET: {{ .anycableTurboStreamsSecret | toString | b64enc | quote }} # {{ .anycableTurboStreamsSecret }}
+  {{- end }}
+  {{- if .anycableSecret }}
+  ANYCABLE_SECRET: {{ .anycableSecret | toString | b64enc | quote }} # {{ .anycableSecret }}
+  {{- end }}
+  {{- if .anycablePublic }}
+  ANYCABLE_PUBLIC: {{ .anycablePublic | toString | b64enc | quote }} # {{ .anycablePublic }}
+  {{- end }}
+  {{- if .anycabelStreamsWhisper }}
+  ANYCABLE_STREAMS_WHISPER: {{ .anycabelStreamsWhisper | toString | b64enc | quote }} # {{ .anycabelStreamsWhisper }}
+  {{- end }}
+  {{- if .anycableCableReadySecret }}
+  ANYCABLE_CABLE_READY_SECRET: {{ .anycableCableReadySecret | toString | b64enc | quote }} # {{ .anycableCableReadySecret }}
   {{- end }}
   {{- if .anycableCableReadyKey }}
   ANYCABLE_CABLE_READY_KEY: {{ .anycableCableReadyKey | toString | b64enc | quote }} # {{ .anycableCableReadyKey }}
-  {{- end }}
-  {{- if .anycableCableReadyCleartext }}
-  ANYCABLE_CABLE_READY_CLEARTEXT: {{ .anycableCableReadyCleartext | toString | b64enc | quote }} # {{ .anycableCableReadyCleartext }}
   {{- end }}
   {{- if .anycableSse }}
   ANYCABLE_SSE: {{ .anycableSse | toString | b64enc | quote }} # {{ .anycableSse }}

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -11,7 +11,7 @@ hpa:
 
 image:
   repository: anycable/anycable-go
-  tag: 1.4.1
+  tag: 1.5.3
   pullPolicy: IfNotPresent
   pullSecrets:
     enabled: false
@@ -388,26 +388,51 @@ env:
   # How long to wait for a pong response before disconnecting the client (in seconds). Zero means no pongs require.
   anycablePongTimeout: "0"
 
-  # The encryption key used to verify JWT tokens, default: "" (disabled)
+  # [DEPRECATED] The encryption key used to verify JWT tokens, default: "" (disabled)
   anycableJwtIdKey: ""
 
-  # The name of a query string param or an HTTP header carrying a token, default: "jid" ("X-JID")
+  # The encryption key used to verify JWT tokens, default: "" (disabled)
+  anycableJwtSecret: ""
+
+  # [DEPRECATED] The name of a query string param or an HTTP header carrying a token, default: "jid" ("X-JID")
   anycableJwtIdParam: "jid"
 
-  # Whether to enforce token presence for all connections, default: false
+  # The name of a query string param or an HTTP header carrying a token, default: "jid" ("X-JID")
+  anycableJwtParam: "jid"
+
+  # [DEPRECATED] Whether to enforce token presence for all connections, default: false
   anycableJwtIdEnforce: "false"
 
-  # Enable Turbo Streams fastlane with the specified signing key, default: "" (disabled)
+  # Whether to enforce token presence for all connections, default: false
+  anycableEnforceJwt: "false"
+
+  # Enable public (unsigned) streams support, default: false
+  anycablePublicStreams: "false"
+
+  # Secret key to verify signed streams, default: "" (disabled)
+  anycableStreamsSecret: ""
+
+  # [DEPRECATED] Enable Turbo Streams fastlane with the specified signing key, default: "" (disabled)
   anycableTurboRailsKey: ""
 
-  # Enable Turbo Streams fastlane without stream names signing
-  anycableTurboRailsCleartext: "false"
+  # Enable Turbo Streams fastlane with the specified signing secret, default: "" (disabled)
+  anycableTurboStreamsSecret: ""
 
-  # Enable CableReady fastlane with the specified signing key, default: "" (disabled)
+  # [DEPRECATED] Enable CableReady fastlane with the specified signing key, default: "" (disabled)
   anycableCableReadyKey: ""
 
-  # Enable Cable Ready fastlane without stream names signing
-  anycableCableReadyCleartext: "false"
+  # Enable CableReady fastlane with the specified signing secret, default: "" (disabled)
+  anycableCableReadySecret: ""
+
+  # Single secret is enough to secure all AnyCable features, default: "" (disabled)
+  anycableSecret: ""
+
+  # No authentication (unless JWT specified), public streams, no HTTP broadcasting authentication, default: false
+  anycablePublic: "false"
+
+  # Whispering is an ability for client to publish events to the subscribed stream without involving
+  # any server-side logic, for signed streams, default: false
+  anycabelStreamsWhisper: "false"
 
   # Enable SSE endpoint
   anycableSse: "false"


### PR DESCRIPTION
Removed deprecated values:
* ANYCABLE_TURBO_RAILS_CLEARTEXT
* ANYCABLE_CABLE_READY_CLEARTEXT

Added new values:

* ANYCABLE_REDIS_DISABLE_CACHE
* ANYCABLE_JWT_SECRET
* ANYCABLE_PUBLIC_STREAMS
* ANYCABLE_STREAMS_SECRET
* ANYCABLE_TURBO_STREAMS_SECRET
* ANYCABLE_SECRET
* ANYCABLE_PUBLIC
* ANYCABLE_STREAMS_WHISPER
* ANYCABLE_CABLE_READY_SECRET
