### PR TITLE
Update ingress-tls-secret.yml

### DIFF
--- a/anycable-go/templates/ingress-tls-secret.yml
+++ b/anycable-go/templates/ingress-tls-secret.yml
@@ -1,15 +1,15 @@
 {{- $values := include "anycableGo.values" . | fromYaml }}
-{{- with ($values.ingress.nonAcme.hosts | default dict) }}
-{{- if (.tls | and .tls.key | and .tls.crt) }}
+{{- range $host := ($values.ingress.nonAcme.hosts | default list) }}
+  {{- if ($host.tls | and $host.tls.key | and $host.tls.crt) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: {{ .secretName }}
+  name: {{ $host.secretName }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .tls.crt | b64enc | quote }}
-  tls.key: {{ .tls.key | b64enc | quote }}
-{{- end }}
+  tls.crt: {{ $host.tls.crt | b64enc | quote }}
+  tls.key: {{ $host.tls.key | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #47 

The normal TLS secret is stored in the tls-secret.yaml, but this ingress-tls-secret should respond to the nonAcme.hosts, which is doing it now.