### PR TITLE
(anycable-go: v0.7.1) Remove default resource limits to fix partial override issues

### DIFF
--- a/anycable-go/Chart.yaml
+++ b/anycable-go/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for anycable-go websocket server.
 name: anycable-go
-version: 0.7.0
+version: 0.7.1
 appVersion: 1.6.6
 kubeVersion: ">=1.23.0-0"
 home: https://anycable.io/

--- a/anycable-go/values.yaml
+++ b/anycable-go/values.yaml
@@ -56,15 +56,15 @@ rollingUpdate:
   maxSurge: 1
   maxUnavailable: 0
 
-# Default resource limits for items API app.
-# Do not forget to tune them to match your needs.
-resources:
-  limits:
-    cpu: 350m
-    memory: 400Mi
-  requests:
-    cpu: 350m
-    memory: 400Mi
+# Resource requests/limits are intentionally unset and these are the default resources recommended.
+# Set them in your values override to match your workload.
+# resources:
+#   limits:
+#     cpu: 350m
+#     memory: 400Mi
+#   requests:
+#     cpu: 350m
+#     memory: 400Mi
 
 pod:
   annotations: {}


### PR DESCRIPTION
### Summary

- Remove default resources values to prevent Helm deep-merge issues when users partially override resource requests/limits
- Bump chart version to 0.7.1

### Problem

When users set partial resource overrides like:
```yml
resources:
  requests:
    cpu: 1
    memory: 2G
  limits:
    memory: 2G
```

Helm deep-merges these with the chart defaults, resulting in:
```yml
resources:
  requests:
    cpu: 1        # 1000m from user
    memory: 2G
  limits:
    cpu: 350m     # from defaults (not overridden)
    memory: 2G
```

This causes Kubernetes validation errors: `requests.cpu (1000m)` > `limits.cpu (350m)` (`spec.template.spec.containers[0].resources.requests: Invalid value: "1": must be less than or equal to cpu limit of 350m`)

### Proposed Solution

Remove default resource values so users have full control. This is a common pattern for Helm charts to avoid unexpected merge behavior.